### PR TITLE
Add dark mode toggle

### DIFF
--- a/tarimas-interface/app/page.tsx
+++ b/tarimas-interface/app/page.tsx
@@ -24,6 +24,7 @@ import {
 import { toast } from "@/components/ui/use-toast"
 import { Toaster } from "@/components/ui/toaster"
 import SeleccionResumen from "@/components/SeleccionResumen"; // Ajusta la ruta si es necesario
+import ModeToggle from "@/components/mode-toggle"
 
 
 // Actualizar la interfaz para incluir los nuevos campos
@@ -666,9 +667,10 @@ return (
             <Badge variant="outline" className="text-sm">
               {tarimas.length} tarimas disponibles
             </Badge>
-            <Button 
-  size="sm" 
-  variant="outline" 
+            <ModeToggle />
+            <Button
+  size="sm"
+  variant="outline"
   onClick={handleResetAndRefresh} // <--- CAMBIO AQUÍ
   disabled={loading} // 'loading' se refiere al estado de carga de fetchTarimas
 >

--- a/tarimas-interface/components/mode-toggle.tsx
+++ b/tarimas-interface/components/mode-toggle.tsx
@@ -1,0 +1,22 @@
+"use client"
+
+import { Moon, Sun } from "lucide-react"
+import { useTheme } from "next-themes"
+
+import { Button } from "@/components/ui/button"
+
+export default function ModeToggle() {
+  const { theme, setTheme } = useTheme()
+
+  function toggleTheme() {
+    setTheme(theme === "dark" ? "light" : "dark")
+  }
+
+  return (
+    <Button variant="ghost" size="icon" onClick={toggleTheme} aria-label="Alternar tema">
+      <Sun className="size-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
+      <Moon className="absolute size-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
+      <span className="sr-only">Alternar tema</span>
+    </Button>
+  )
+}


### PR DESCRIPTION
## Summary
- add `ModeToggle` component
- include theme switcher in page header

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6862b46cc66c833189fdee46532d06da