### PR TITLE
Add releases JSON editor tab

### DIFF
--- a/tarimas-interface/app/page.tsx
+++ b/tarimas-interface/app/page.tsx
@@ -40,6 +40,7 @@ import TarimasTab from "@/components/tarimas/TarimasTab";
 
 // Componentes de Excel - AGREGADO
 import ExcelTab from "@/components/excel/ExcelTab";
+import ReleasesTab from "@/components/releases/ReleasesTab";
 
 // Componentes compartidos
 import ProcessModal from "@/components/shared/ProcessModal";
@@ -347,6 +348,10 @@ export default function Home() {
                   getStats={getStats}
                   getWeightInfo={getWeightInfo}
               />
+          )}
+
+          {activeTab === "releases" && (
+              <ReleasesTab />
           )}
         </main>
 

--- a/tarimas-interface/components/layout/TabNavigation.tsx
+++ b/tarimas-interface/components/layout/TabNavigation.tsx
@@ -1,6 +1,6 @@
 // components/layout/TabNavigation.tsx
 import { Button } from "@/components/ui/button";
-import { Package, Search } from "lucide-react";
+import { Package, Search, FileSpreadsheet } from "lucide-react";
 import { ActiveTab } from "@/types";
 
 interface TabNavigationProps {
@@ -22,6 +22,12 @@ export default function TabNavigation({ activeTab, onTabChange, selectedCount }:
             label: "Filtrar por Excel",
             icon: Search,
             description: "Busca productos específicos"
+        },
+        {
+            id: "releases" as ActiveTab,
+            label: "Releases",
+            icon: FileSpreadsheet,
+            description: "Editar JSON"
         }
     ];
 

--- a/tarimas-interface/components/releases/ReleasesTab.tsx
+++ b/tarimas-interface/components/releases/ReleasesTab.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
+
+export default function ReleasesTab() {
+  const [data, setData] = useState<any[]>([]);
+  const [columns, setColumns] = useState<string[]>([]);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      try {
+        const text = event.target?.result as string;
+        const json = JSON.parse(text);
+        const arr = Array.isArray(json) ? json : [json];
+        setData(arr);
+        setColumns(Object.keys(arr[0] || {}));
+      } catch (err) {
+        console.error("Error parsing JSON", err);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  const handleCellChange = (rowIndex: number, key: string, value: string) => {
+    const newData = [...data];
+    newData[rowIndex][key] = value;
+    setData(newData);
+  };
+
+  return (
+    <div className="space-y-4">
+      <Input type="file" accept=".json" onChange={handleFileChange} />
+      {data.length > 0 && (
+        <div className="overflow-auto">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                {columns.map((col) => (
+                  <TableHead key={col}>{col}</TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {data.map((row, rowIndex) => (
+                <TableRow key={rowIndex}>
+                  {columns.map((col) => (
+                    <TableCell key={col} className="p-1">
+                      <Input
+                        value={row[col] as string}
+                        onChange={(e) => handleCellChange(rowIndex, col, e.target.value)}
+                      />
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tarimas-interface/types/index.ts
+++ b/tarimas-interface/types/index.ts
@@ -34,7 +34,7 @@ export interface ApiFilterResponseItem {
     datos: Tarima[];
 }
 
-export type ActiveTab = "tarimas" | "excel";
+export type ActiveTab = "tarimas" | "excel" | "releases";
 
 export interface TarimasStats {
     totalCajas: number;


### PR DESCRIPTION
## Summary
- add new releases tab to navigation
- implement `ReleasesTab` component to load and edit JSON files like an Excel table
- wire releases tab into main page
- extend allowed tab types

## Testing
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_6862bc78109483319b4a7fe2c72d26ee